### PR TITLE
Remove useless unit test

### DIFF
--- a/test/getDeployConfig.js
+++ b/test/getDeployConfig.js
@@ -6,11 +6,6 @@ const proxyquire = require('proxyquire')
 const expectedConfig = require('./config.json')
 
 describe('getDeployConfig', function () {
-  it('should do thing', function (done) {
-    assert.strictEqual(true, true)
-    done()
-  })
-
   it('should grab a deploy file from command line args', function (done) {
     const yargsParserStub = sinon.stub().returns({
       deployFile: path.join(`${__dirname}/config.json`)


### PR DESCRIPTION
There was a unit test that was originally likely put in test/getDeployConfig.js when I was setting up the testing framework in source-configs. removing it now.