### PR TITLE
Fix primitive description keyword when not a string (Closes #118)

### DIFF
--- a/sourceConfig.js
+++ b/sourceConfig.js
@@ -173,12 +173,13 @@ function checkEnum (path, configResult, configObject) {
  * @return {boolean} - boolean result of if it is a primitive
  */
 function isPrimitive (configObject) {
-  return Object.keys(configObject).length === 0 ||
+  return typeof configObject.description !== 'object' && // If description is not a string it is another configured config item and not a primitive, return false
+    (Object.keys(configObject).length === 0 ||
     configObject.default !== undefined ||
     configObject.commandLineArg !== undefined ||
     configObject.description !== undefined ||
     configObject.values !== undefined ||
-    configObject.envVar !== undefined
+    configObject.envVar !== undefined)
 }
 
 /**


### PR DESCRIPTION
Fix primitive word description flagging as a primitive when not a string. In the case that it is set to an object it is an additional configuration layer

(Closes #118)