### PR TITLE
Ensure each usage loads config in isolation

### DIFF
--- a/test/commandLineArgs.js
+++ b/test/commandLineArgs.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 const assert = require('assert')
+const processArgv = process.argv.slice()
 
 const commandLineArguments = {
   'api-route': '/api/b',
@@ -11,41 +12,48 @@ const commandLineArguments = {
 let sourceConfig
 let schema
 
-describe('Command Line Arguments', function () {
-  beforeEach(function (done) {
+describe('Command Line Arguments', () => {
+  before(() => {
+    // setup some cli flags
+    process.argv = []
+    process.argv.push('node')
+    process.argv.push('app.js')
+    process.argv.push('--api-route')
+    process.argv.push('/api/b')
+    process.argv.push('--timeout')
+    process.argv.push('4000')
+    process.argv.push('--ex-bool')
+    process.argv.push('-a')
+    process.argv.push('foobar')
+
     sourceConfig = require('../sourceConfig')
     sourceConfig.configs = {}
     schema = require('./schema.json')
 
-    sourceConfig.commandLineArgs = commandLineArguments
-
     sourceConfig(schema)
-
-    done()
   })
 
-  it('should expect an object parsed beforehand', function (done) {
+  after(() => {
+    process.argv = processArgv
+  })
+
+  it('should expect an object parsed beforehand', () => {
     assert.deepStrictEqual(sourceConfig.configs.apiRoute, commandLineArguments['api-route'])
-    done()
   })
 
-  it('will parse strings to ints', function (done) {
+  it('will parse strings to ints', () => {
     assert.deepStrictEqual(sourceConfig.configs.timeout, 4000)
-    done()
   })
 
-  it('will parse strings to bools', function (done) {
+  it('will parse strings to bools', () => {
     assert.deepStrictEqual(sourceConfig.configs.exBool, true)
-    done()
   })
 
-  it('will work with an array of command line args', function (done) {
+  it('will work with an array of command line args', () => {
     assert.deepStrictEqual(sourceConfig.configs.commandLineArgArray, 'foobar')
-    done()
   })
 
-  it('will return the default if a field is not in a command line argument', function (done) {
+  it('will return the default if a field is not in a command line argument', () => {
     assert.deepStrictEqual(sourceConfig.configs.exString, 'String')
-    done()
   })
 })

--- a/test/customization.js
+++ b/test/customization.js
@@ -1,21 +1,25 @@
 /* eslint-env mocha */
 const assert = require('assert')
-
+const processArgv = process.argv.slice()
 let sourceConfig
 let schema
 
-describe('environment variables', function () {
-  beforeEach(function (done) {
+describe('custom configuration', function () {
+  before(() => {
+    // add some cli arguments
+    process.argv.push('--api-route')
+    process.argv.push('/api/b')
+
     schema = require('./schema.json')
     sourceConfig = require('../sourceConfig')
-    sourceConfig.commandLineArgs = {
-      'api-route': '/api/b'
-    }
-    sourceConfig.configs = {}
-    done()
   })
 
-  it('should prioritize custom source object', function (done) {
+  after(() => {
+    // reset cli argument set
+    process.argv = processArgv
+  })
+
+  it('should prioritize custom source object', () => {
     sourceConfig(schema, {
       logging: false,
       sources: [
@@ -24,10 +28,9 @@ describe('environment variables', function () {
       ]
     })
     assert.strictEqual(sourceConfig.configs.apiRoute, '/api/c')
-    done()
   })
 
-  it('should post-process config with transform function', function (done) {
+  it('should post-process config with transform function', () => {
     sourceConfig(schema, {
       logging: false,
       transform: (params, flags) => {
@@ -39,6 +42,5 @@ describe('environment variables', function () {
       }
     })
     assert.strictEqual(sourceConfig.configs.apiRoute, '/api/d')
-    done()
   })
 })

--- a/test/deployConfig.js
+++ b/test/deployConfig.js
@@ -1,32 +1,28 @@
 /* eslint-env mocha */
 const assert = require('assert')
-
+const processArv = process.argv.slice()
 let sourceConfig
 let schema
 
-describe('Deploy config', function () {
-  beforeEach(function (done) {
+describe('Deploy config', () => {
+  before(() => {
+    process.argv = []
     process.env.DEPLOY_CONFIG = './test/config.json'
     sourceConfig = require('../sourceConfig')
     schema = require('./schema.json')
-    sourceConfig.configs = {}
-    sourceConfig.commandLineArgs = {}
     sourceConfig(schema)
-    done()
   })
 
-  afterEach(function (done) {
-    process.env.DEPLOY_CONFIG = ''
-    done()
+  after(() => {
+    delete process.env.DEPLOY_CONFIG
+    process.argv = processArv
   })
 
-  it('should get fields from the deploy config file', function (done) {
+  it('should get fields from the deploy config file', () => {
     assert.strictEqual(sourceConfig.configs.timeout, 400)
-    done()
   })
 
-  it('should default to the defaults if a field isn\'t in the deploy config file', function (done) {
+  it('should default to the defaults if a field isn\'t in the deploy config file', () => {
     assert.strictEqual(sourceConfig.configs.apiRoute, '/api/')
-    done()
   })
 })

--- a/test/deployConfigFromPackage.js
+++ b/test/deployConfigFromPackage.js
@@ -12,7 +12,7 @@ describe('getConfigFromPackage', function () {
   it('should grab a deploy file from package', function (done) {
     const key = path.join(projectRoot.path, 'package.json')
 
-    const { config } = proxyquire('../getDeployConfig', { [key]: { deployConfig: mockPackage.deployConfig } })
+    const config = proxyquire('../getDeployConfig', { [key]: { deployConfig: mockPackage.deployConfig } })()
 
     assert.deepStrictEqual(config, expectedConfig)
 
@@ -24,12 +24,12 @@ describe('getConfigFromPackage', function () {
 
     const key = path.join(projectRoot.path, 'package.json')
 
-    const { config } = proxyquire('../getDeployConfig', {
+    const config = proxyquire('../getDeployConfig', {
       [key]: { deployConfig: mockPackageHome.deployConfig },
       fs: {
         readFileSync: fsStub
       }
-    })
+    })()
 
     assert.deepStrictEqual(config, expectedConfig)
 

--- a/test/enum.js
+++ b/test/enum.js
@@ -1,49 +1,43 @@
 /* eslint-env mocha */
 const assert = require('assert')
-
+const processArgv = process.argv.slice()
 let sourceConfig
 let schema
 
-describe('Enums', function () {
-  beforeEach(function (done) {
+describe('Enums', () => {
+  before(() => {
     sourceConfig = require('../sourceConfig')
     schema = require('./schema.json')
     sourceConfig.configs = {}
-    done()
   })
 
-  it('should pass with a valid enum', function (done) {
-    const commandLineArguments = {
-      'http-method': 'http'
-    }
-    sourceConfig.commandLineArgs = commandLineArguments
+  it('should pass with a valid enum', () => {
+    process.argv.push('--http-method')
+    process.argv.push('http')
 
     sourceConfig(schema)
     assert.deepStrictEqual(sourceConfig.configs.httpMethod, 'http')
-    done()
+
+    process.argv = processArgv
   })
 
-  it('should use fallback with invalid enum', function (done) {
-    const commandLineArguments = {
-      'http-method': 'httpz'
-    }
-
-    sourceConfig.commandLineArgs = commandLineArguments
+  it('should use fallback with invalid enum', () => {
+    process.argv.push('--http-method')
+    process.argv.push('httpz')
 
     sourceConfig(schema)
     assert.deepStrictEqual(sourceConfig.configs.httpMethod, 'http')
-    done()
+
+    process.argv = processArgv
   })
 
-  it('should use passed arg with invalid enum and no default', function (done) {
-    const commandLineArguments = {
-      'no-default': 'sometimes'
-    }
-
-    sourceConfig.commandLineArgs = commandLineArguments
+  it('should use passed arg with invalid enum and no default', () => {
+    process.argv.push('--no-default')
+    process.argv.push('sometimes')
 
     sourceConfig(schema)
     assert.deepStrictEqual(sourceConfig.configs.enumWithoutDefault, null)
-    done()
+
+    process.argv = processArgv
   })
 })

--- a/test/envirionmentVariables.js
+++ b/test/envirionmentVariables.js
@@ -1,53 +1,58 @@
 /* eslint-env mocha */
 const assert = require('assert')
-
+const processArgv = process.argv.slice()
 let sourceConfig
 let schema
 
-describe('environment variables', function () {
-  beforeEach(function (done) {
+describe('environment variables', () => {
+  before(() => {
+    process.argv = []
     schema = require('./schema.json')
     sourceConfig = require('../sourceConfig')
-    sourceConfig.commandLineArgs = {}
-    sourceConfig.configs = {}
-    done()
   })
 
-  it('should take a plain environment variable', function (done) {
+  after(() => {
+    process.argv = processArgv
+  })
+
+  it('should take a plain environment variable', () => {
     process.env.API_ROUTE = '/api'
 
     sourceConfig(schema)
     assert.strictEqual(sourceConfig.configs.apiRoute, '/api')
-    done()
+
+    delete process.env.API_ROUTE
   })
 
-  it('should map a number string to an int', function (done) {
+  it('should map a number string to an int', () => {
     process.env.TIMEOUT = '20'
 
     sourceConfig(schema)
     assert.strictEqual(sourceConfig.configs.timeout, 20)
-    done()
+
+    delete process.env.TIMEOUT
   })
 
-  it('should map a bool string to a bool', function (done) {
+  it('should map a bool string to a bool', () => {
     process.env.EX_BOOL = 'true'
 
     sourceConfig(schema)
     assert.strictEqual(sourceConfig.configs.exBool, true)
-    done()
+
+    delete process.env.EX_BOOL
   })
 
-  it('should support arrays of environment variables', function (done) {
+  it('should support arrays of environment variables', () => {
     process.env.FOO = 10
 
     sourceConfig(schema)
     assert.strictEqual(sourceConfig.configs.envVarArray, 10)
-    done()
+
+    delete process.env.FOO
   })
 
-  it('should default when not passed in anything', function (done) {
+  it('should default when not passed in anything', () => {
     sourceConfig(schema)
     assert.strictEqual(sourceConfig.configs.exString, 'String')
-    done()
   })
 })

--- a/test/getDeployConfig.js
+++ b/test/getDeployConfig.js
@@ -11,7 +11,7 @@ describe('getDeployConfig', function () {
       deployConfigFile: path.join(`${__dirname}/config.json`)
     })
 
-    const { config } = proxyquire('../getDeployConfig', { 'yargs-parser': yargsParserStub })
+    const config = proxyquire('../getDeployConfig', { 'yargs-parser': yargsParserStub })()
 
     assert.deepStrictEqual(config, expectedConfig)
 
@@ -23,7 +23,7 @@ describe('getDeployConfig', function () {
       deployConfigFile: path.join(`${__dirname}/foo.json`)
     })
 
-    const { config } = proxyquire('../getDeployConfig', { 'yargs-parser': yargsParserStub })
+    const config = proxyquire('../getDeployConfig', { 'yargs-parser': yargsParserStub })()
 
     assert.strictEqual(config, null)
     done()
@@ -34,7 +34,7 @@ describe('getDeployConfig', function () {
       deployConfigFile: path.join(`${__dirname}/invalidConfig.json`)
     })
 
-    const { config } = proxyquire('../getDeployConfig', { 'yargs-parser': yargsParserStub })
+    const config = proxyquire('../getDeployConfig', { 'yargs-parser': yargsParserStub })()
 
     assert.strictEqual(config, null)
     done()


### PR DESCRIPTION
These under the hood refactors ensure that in the (unlikely) scenario that source-configs is required twice in the same process the first instance doesn't pollute future instances.