### PR TITLE
Improve the rigor of parsing command line args in schema

### DIFF
--- a/sourceConfig.js
+++ b/sourceConfig.js
@@ -142,10 +142,14 @@ function checkConfig (path, configObject, commandLineArgs, sources) {
     if (source === 'command line' || source.name === 'commandLineArg') {
       if (commandLineArgs !== undefined && configObject.commandLineArg !== undefined) {
         if (isStringArray(configObject.commandLineArg)) {
-          for (const arg of configObject.commandLineArg) {
-            if (commandLineArgs[arg.slice(2)] !== undefined) {
-              value = commandLineArgs[arg.slice(2)]
-              break
+          const parsedArgs = yargsParser(configObject.commandLineArg)
+
+          for (const arg in parsedArgs) {
+            if (arg !== '_') {
+              if (commandLineArgs[arg] !== undefined) {
+                value = commandLineArgs[arg]
+                break
+              }
             }
           }
 

--- a/test/schema.json
+++ b/test/schema.json
@@ -24,7 +24,7 @@
     "default": "String"
   },
   "commandLineArgArray": {
-    "commandLineArg": ["--arg-array", "--a"],
+    "commandLineArg": ["--arg-array", "-a"],
     "desc": "Example array of command line args",
     "default": ""
   },


### PR DESCRIPTION
By using yargs to process arg lists from the schema we ensure that we parse them in a format agnostic way (i.e, `-a` or `--a` will both function).

Closes #198