### PR TITLE
Update source-configs.js to allow for empty string to be set from ENV variables

### DIFF
--- a/source-configs.js
+++ b/source-configs.js
@@ -213,7 +213,7 @@ function checkConfig (path, configObject, commandLineArgs, sources) {
       if (configObject.envVar !== undefined) {
         if (isStringArray(configObject.envVar)) {
           for (const envVar of configObject.envVar) {
-            if (process.env[envVar]) {
+            if (Object.hasOwn(process.env, envVar)) {
               value = process.env[envVar]
               break
             }


### PR DESCRIPTION
This change allows for empty string to be set from ENV variables which is different than unsetting the ENV. The original if check would return false because empty string is falsey. The change explicitly checks the process.env JSON to see if the key exists and then sets the variable to whatever is there (which can now be empty string)