### PR TITLE
Same change as #378 to an overlooked line

### DIFF
--- a/source-configs.js
+++ b/source-configs.js
@@ -223,7 +223,7 @@ function checkConfig (path, configObject, commandLineArgs, sources) {
             break
           }
         } else {
-          if (process.env[configObject.envVar]) {
+          if (Object.hasOwn(process.env, configObject.envVar)) {
             value = process.env[configObject.envVar]
             break
           }


### PR DESCRIPTION
This change allows for empty string to be set from ENV variables which is different than unsetting the ENV. The original if check would return false because empty string is falsey. The change explicitly checks the process.env JSON to see if the key exists and then sets the variable to whatever is there (which can now be empty string)

Continuation of #378 